### PR TITLE
fix: Correct Header component import casing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import Header from '@/components/layout/header'
+import Header from '@/components/layout/Header'
 import Companies from '@/components/companies/Companies'
 
 function App() {


### PR DESCRIPTION
This PR corrects a typo in the import statement for the Header component within `\src\App.tsx`, changing `import header` to `import Header`.